### PR TITLE
Bootstrapping support for r10k based puppet code deployment for puppet master

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,10 +10,8 @@ Vagrant.configure("2") do |config|
     puppet.vm.network "private_network", ip:"192.168.33.10" 
     puppet.vm.provision "shell", inline: <<-MASTER
       yum install --nogpgcheck https://yum.puppet.com/puppet5/puppet5-release-el-7.noarch.rpm -y
-      yum install git -y
-      yum install -y puppetserver
-      rpm -Uvh https://yum.puppet.com/puppet-tools-release-el-7.noarch.rpm
-      yum install -y puppet-bolt
+      yum install git -y --nogpgcheck
+      yum install -y puppetserver --nogpgcheck
       echo '127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
       ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
       192.168.33.10  puppet.example.com puppet
@@ -23,52 +21,16 @@ Vagrant.configure("2") do |config|
       sudo hostname puppet.example.com
       systemctl enable puppetserver
       systemctl start puppetserver
-      export PATH=$PATH:/opt/puppetlabs/puppet/bin
+      echo 'export PATH=$PATH:/opt/puppetlabs/puppet/bin' >> ~/.bashrc
+      /opt/puppetlabs/puppet/bin/gem install r10k
       mkdir /etc/puppetlabs/r10k
-      cat /dev/zero | ssh-keygen -q -N ""
-      echo '-----BEGIN RSA PRIVATE KEY-----
-      MIIEogIBAAKCAQEAsN3x1XYZQTXn/XMcdcbfC3QsEnlz11GYiL+z6dU+xrsGE/oJ
-      amxczx6RMZnQs4avoo6xVTAcQyPjtGpR2OdynMGc21BAdh+u3bYWda3Uo5pQr3S3
-      rorEH3T4sAnk+WuZ2drjQqO3lwXwDFs6cyHDXqiIFNHjv08ebnFynWkNGrYXvDTg
-      QNxCFEBYwreuFUrHeoUzwkjR/1uQ26rcLIXPJkWh1jVrtxWWx+bnPucn4IxC+x1C
-      tRrywnhoIbAzaqiIK36KcYWftFtV1SK+Sk1e1F3fNPVs4AZJz7EgcnPRWQOJrxqL
-      JCRdtY6y8O3kJyxvvqSMenDnmIDdMA8znfEFYQIDAQABAoIBACddzyT++1ILaI5+
-      H5iLYjvPaLvX8pO7YqMVYDssrqNXH1w07AGXCvVCzXhnzw8WbGNXNVtLsQ60n0sZ
-      2wvXQChp47rg2ugv1yEcFVWuEkUz5L+Y0AV2d36072FnYmKts3nNAYZkoElqFer6
-      J0FXA4A/LMLNkM6VEqXsdGFa74LBI/gxA5V5zcMaNvUjroAaNEXnAiSfhSnJu+rW
-      EnsZ/zxxjjiZBs3+UtbCuklxmO3HttjR6xYWDOzyZBZrY+DT/g6DAesMVR3WIKSm
-      s4PNWEnMTzRkVjbfEZ5OzMVbW/+ysdzWhoem4dBj+tNCtfLWjIrOW8LLpGfv7X8o
-      kXaNCy0CgYEA5c2TMBH3CZlkUSOTZfE2ZQhuxFtDxNH2nHjnxHJIiX2b68vPh7OT
-      KJwpnXv/nihjkTOLmN+5BG96lNSSksjikuAqySFhYBKpuJ482dMhz7QTH9tHubi3
-      VMwtUgktF2HdYgYAdixqOhuegU0SZYi3coFgpX5frZ8hWgsiCsPzIw8CgYEAxQeE
-      gbhW1ZaJOnmXYVQr5RFHEKg5MiZFWjw5BbNi8h0cKOJhRJucq5yKQJRqt3uZwd0J
-      X2wHO6YjIsU3+25fOSaYGrYMn6Bfj18ZRor8hhpd/+drWcS1USBcCXI98fvOHWts
-      wL4jhJO/LF7yezRk9aJNNhjFlT2nXxPm4iQYkI8CgYAY0n7Ol3IuuEHsvcIDJe3x
-      Ndr5HL6SOPfBaRHn10xchZPdAXPWPaBsp4mbODShOc2fdojip2/Nudjs0JVQg6Bt
-      qwcUGKXzAbERfw4lnTeuvs2+CCqUNg6fezp9/P3A49JM70cHfL6wriEN6GxPSVg/
-      ZxgwaBkfoOuyVTeFICtYIwKBgFRFneBZ9xIN/A39ucjQVqH4XNv8B9KyWdF5lq4g
-      hv6lgsjd4tqUcFNadiufD3IBNMedggfFTeaubbLOhd5N2/62yjIKkaWo05agB1CL
-      2+yD1JbC5cCUiTT00UjdCy+4EvW0X+Skrs5i307cIXye8Vu6mqm7uK7XmwHookUx
-      SSxzAoGAL7xFixnPytyUOCIApiNIAjhdzt3ncTxuxUnKZDUfA5k9dCfuTHY4iiWT
-      X3GjPua9AWG6dgxmvQDs0mUpYbCamlPkiRAIJGjykZo2ZM28mp7Pe9T7SzxtyISs
-      uM/Q3RMroEPxA2Harz+sSEtp9MR6IhmeJb4fSv57U289Qs84R6A=
-      -----END RSA PRIVATE KEY-----' > ~/.ssh/id_rsa
-
-      chmod 600 ~/.ssh/id_rsa
-      echo 'ssh-rsa
-      AAAAB3NzaC1yc2EAAAADAQABAAABAQCw3fHVdhlBNef9cxx1xt8LdCwSeXPXUZiIv7Pp1T7GuwYT+glqbFzPHpExmdCzhq+ijrFVMBxDI+O0alHY53KcwZzbUEB2H67dthZ1rdSjmlCvdLeuisQfdPiwCeT5a5nZ2uNCo7eXBfAMWzpzIcNeqIgU0eO/Tx5ucXKdaQ0athe8NOBA3EIUQFjCt64VSsd6hTPCSNH/W5Dbqtwshc8mRaHWNWu3FZbH5uc+5yfgjEL7HUK1GvLCeGghsDNqqIgrfopxhZ+0W1XVIr5KTV7UXd809WzgBknPsSByc9FZA4mvGoskJF21jrLw7eQnLG++pIx6cOeYgN0wDzOd8QVh vagrant@puppet.example.com' > ~/.ssh/id_rsa.pub
-      chmod 600 ~/.ssh/id_rsa.pub
-      echo '' > ~/.ssh/authorized_keys
-      chmod 600 ~/.ssh/authorized_keys
-      
-      gem install r10k
       echo '---' > /etc/puppetlabs/r10k/r10k.yaml
       echo '  :cachedir: /var/cache/r10k' >> /etc/puppetlabs/r10k/r10k.yaml
       echo '  :sources:' >> /etc/puppetlabs/r10k/r10k.yaml 
       echo '    :local:' >> /etc/puppetlabs/r10k/r10k.yaml  
       echo '      remote: https://github.com/faintdream/r10k-site' >> /etc/puppetlabs/r10k/r10k.yaml
       echo '      basedir: /etc/puppetlabs/code/environments' >> /etc/puppetlabs/r10k/r10k.yaml
-      
+      export PATH=$PATH:/opt/puppetlabs/puppet/bin
       r10k deploy environment -pv
     MASTER
   end 
@@ -81,8 +43,8 @@ Vagrant.configure("2") do |config|
     node.vm.network "private_network", ip:"192.168.33.20" 
     node.vm.provision "shell", inline: <<-NODE
       yum install --nogpgcheck https://yum.puppet.com/puppet5/puppet5-release-el-7.noarch.rpm -y
-      yum install git -y
-      yum install -y puppet
+      yum install git -y --nogpgcheck
+      yum install -y puppet --nogpgcheck
       echo '127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
       ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
       192.168.33.20 node
@@ -99,12 +61,13 @@ Vagrant.configure("2") do |config|
     end
     ubuntu.vm.network "private_network", ip:"192.168.33.21" 
     ubuntu.vm.provision "shell", inline: <<-UBUNTU
-      apt-get install wget
-      wget https://apt.puppetlabs.com/puppet5-release-bionic.deb
-      apt-get install puppet5-release-bionic.deb -y
+      export DEBIAN_FRONTEND=noninteractive
+      apt-get install wget --allow-unauthenticated
+      wget --quiet install https://apt.puppetlabs.com/puppet5-release-bionic.deb 
+      dpkg -i puppet5-release-bionic.deb
       apt-get update
-      apt-get install puppet -y
-      apt-get install git -y
+      apt-get install puppet -y --allow-unauthenticated
+      apt-get install git -y --allow-unauthenticated
       echo '127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
       ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
       192.168.33.21 ubuntu

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,13 +8,12 @@ Vagrant.configure("2") do |config|
       vb.customize ["modifyvm", :id, "--cpus", "2"]
     end
     puppet.vm.network "private_network", ip:"192.168.33.10" 
-    puppet.vm.provision "shell", inline: <<-ANOTHERONE
+    puppet.vm.provision "shell", inline: <<-MASTER
       yum install --nogpgcheck https://yum.puppet.com/puppet5/puppet5-release-el-7.noarch.rpm -y
       yum install git -y
       yum install -y puppetserver
       rpm -Uvh https://yum.puppet.com/puppet-tools-release-el-7.noarch.rpm
       yum install -y puppet-bolt
-      yum install -y gem
       echo '127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
       ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
       192.168.33.10  puppet.example.com puppet
@@ -24,7 +23,54 @@ Vagrant.configure("2") do |config|
       sudo hostname puppet.example.com
       systemctl enable puppetserver
       systemctl start puppetserver
-    ANOTHERONE
+      export PATH=$PATH:/opt/puppetlabs/puppet/bin
+      mkdir /etc/puppetlabs/r10k
+      cat /dev/zero | ssh-keygen -q -N ""
+      echo '-----BEGIN RSA PRIVATE KEY-----
+      MIIEogIBAAKCAQEAsN3x1XYZQTXn/XMcdcbfC3QsEnlz11GYiL+z6dU+xrsGE/oJ
+      amxczx6RMZnQs4avoo6xVTAcQyPjtGpR2OdynMGc21BAdh+u3bYWda3Uo5pQr3S3
+      rorEH3T4sAnk+WuZ2drjQqO3lwXwDFs6cyHDXqiIFNHjv08ebnFynWkNGrYXvDTg
+      QNxCFEBYwreuFUrHeoUzwkjR/1uQ26rcLIXPJkWh1jVrtxWWx+bnPucn4IxC+x1C
+      tRrywnhoIbAzaqiIK36KcYWftFtV1SK+Sk1e1F3fNPVs4AZJz7EgcnPRWQOJrxqL
+      JCRdtY6y8O3kJyxvvqSMenDnmIDdMA8znfEFYQIDAQABAoIBACddzyT++1ILaI5+
+      H5iLYjvPaLvX8pO7YqMVYDssrqNXH1w07AGXCvVCzXhnzw8WbGNXNVtLsQ60n0sZ
+      2wvXQChp47rg2ugv1yEcFVWuEkUz5L+Y0AV2d36072FnYmKts3nNAYZkoElqFer6
+      J0FXA4A/LMLNkM6VEqXsdGFa74LBI/gxA5V5zcMaNvUjroAaNEXnAiSfhSnJu+rW
+      EnsZ/zxxjjiZBs3+UtbCuklxmO3HttjR6xYWDOzyZBZrY+DT/g6DAesMVR3WIKSm
+      s4PNWEnMTzRkVjbfEZ5OzMVbW/+ysdzWhoem4dBj+tNCtfLWjIrOW8LLpGfv7X8o
+      kXaNCy0CgYEA5c2TMBH3CZlkUSOTZfE2ZQhuxFtDxNH2nHjnxHJIiX2b68vPh7OT
+      KJwpnXv/nihjkTOLmN+5BG96lNSSksjikuAqySFhYBKpuJ482dMhz7QTH9tHubi3
+      VMwtUgktF2HdYgYAdixqOhuegU0SZYi3coFgpX5frZ8hWgsiCsPzIw8CgYEAxQeE
+      gbhW1ZaJOnmXYVQr5RFHEKg5MiZFWjw5BbNi8h0cKOJhRJucq5yKQJRqt3uZwd0J
+      X2wHO6YjIsU3+25fOSaYGrYMn6Bfj18ZRor8hhpd/+drWcS1USBcCXI98fvOHWts
+      wL4jhJO/LF7yezRk9aJNNhjFlT2nXxPm4iQYkI8CgYAY0n7Ol3IuuEHsvcIDJe3x
+      Ndr5HL6SOPfBaRHn10xchZPdAXPWPaBsp4mbODShOc2fdojip2/Nudjs0JVQg6Bt
+      qwcUGKXzAbERfw4lnTeuvs2+CCqUNg6fezp9/P3A49JM70cHfL6wriEN6GxPSVg/
+      ZxgwaBkfoOuyVTeFICtYIwKBgFRFneBZ9xIN/A39ucjQVqH4XNv8B9KyWdF5lq4g
+      hv6lgsjd4tqUcFNadiufD3IBNMedggfFTeaubbLOhd5N2/62yjIKkaWo05agB1CL
+      2+yD1JbC5cCUiTT00UjdCy+4EvW0X+Skrs5i307cIXye8Vu6mqm7uK7XmwHookUx
+      SSxzAoGAL7xFixnPytyUOCIApiNIAjhdzt3ncTxuxUnKZDUfA5k9dCfuTHY4iiWT
+      X3GjPua9AWG6dgxmvQDs0mUpYbCamlPkiRAIJGjykZo2ZM28mp7Pe9T7SzxtyISs
+      uM/Q3RMroEPxA2Harz+sSEtp9MR6IhmeJb4fSv57U289Qs84R6A=
+      -----END RSA PRIVATE KEY-----' > ~/.ssh/id_rsa
+
+      chmod 600 ~/.ssh/id_rsa
+      echo 'ssh-rsa
+      AAAAB3NzaC1yc2EAAAADAQABAAABAQCw3fHVdhlBNef9cxx1xt8LdCwSeXPXUZiIv7Pp1T7GuwYT+glqbFzPHpExmdCzhq+ijrFVMBxDI+O0alHY53KcwZzbUEB2H67dthZ1rdSjmlCvdLeuisQfdPiwCeT5a5nZ2uNCo7eXBfAMWzpzIcNeqIgU0eO/Tx5ucXKdaQ0athe8NOBA3EIUQFjCt64VSsd6hTPCSNH/W5Dbqtwshc8mRaHWNWu3FZbH5uc+5yfgjEL7HUK1GvLCeGghsDNqqIgrfopxhZ+0W1XVIr5KTV7UXd809WzgBknPsSByc9FZA4mvGoskJF21jrLw7eQnLG++pIx6cOeYgN0wDzOd8QVh vagrant@puppet.example.com' > ~/.ssh/id_rsa.pub
+      chmod 600 ~/.ssh/id_rsa.pub
+      echo '' > ~/.ssh/authorized_keys
+      chmod 600 ~/.ssh/authorized_keys
+      
+      gem install r10k
+      echo '---' > /etc/puppetlabs/r10k/r10k.yaml
+      echo '  :cachedir: /var/cache/r10k' >> /etc/puppetlabs/r10k/r10k.yaml
+      echo '  :sources:' >> /etc/puppetlabs/r10k/r10k.yaml 
+      echo '    :local:' >> /etc/puppetlabs/r10k/r10k.yaml  
+      echo '      remote: https://github.com/faintdream/r10k-site' >> /etc/puppetlabs/r10k/r10k.yaml
+      echo '      basedir: /etc/puppetlabs/code/environments' >> /etc/puppetlabs/r10k/r10k.yaml
+      
+      r10k deploy environment -pv
+    MASTER
   end 
 
   config.vm.define "node" do |node|                                                                       
@@ -33,7 +79,7 @@ Vagrant.configure("2") do |config|
       vb.customize ["modifyvm", :id, "--memory", "1024"]
     end
     node.vm.network "private_network", ip:"192.168.33.20" 
-    node.vm.provision "shell", inline: <<-ANOTHERONE
+    node.vm.provision "shell", inline: <<-NODE
       yum install --nogpgcheck https://yum.puppet.com/puppet5/puppet5-release-el-7.noarch.rpm -y
       yum install git -y
       yum install -y puppet
@@ -44,7 +90,7 @@ Vagrant.configure("2") do |config|
       192.168.33.10 puppet.example.com puppet' > /etc/hosts
       echo "node" >/etc/hostname
       sudo hostname node.example.com
-    ANOTHERONE
+    NODE
   end 
   config.vm.define "ubuntu" do |ubuntu|                                                                       
     ubuntu.vm.box="bento/ubuntu-18.04"      
@@ -52,7 +98,7 @@ Vagrant.configure("2") do |config|
       vb.customize ["modifyvm", :id, "--memory", "1024"]
     end
     ubuntu.vm.network "private_network", ip:"192.168.33.21" 
-    ubuntu.vm.provision "shell", inline: <<-ANOTHERONE
+    ubuntu.vm.provision "shell", inline: <<-UBUNTU
       apt-get install wget
       wget https://apt.puppetlabs.com/puppet5-release-bionic.deb
       apt-get install puppet5-release-bionic.deb -y
@@ -66,7 +112,7 @@ Vagrant.configure("2") do |config|
       192.168.33.10 puppet.example.com puppet' > /etc/hosts
       echo "ubuntu" >/etc/hostname
       sudo hostname ubuntu.example.com
-    ANOTHERONE
+    UBUNTU
   end 
 
 end 


### PR DESCRIPTION
Vagrant gave the flexibility to operate the existing puppet test environment and start/stop when not in use, but every time I would destroy an existing puppet test environment and bring a new one up. the puppet master required to setup manifests & modules manually, which was an unnecessary & time-consuming chore.  To overcome I have bootstrapped r10k support to get all required modules, manifests and default site.pp, this means whenever we launch a new puppet test environment, The puppet master will have an r10k setup which will also download all the previously built modules, this greatly decreases the manual steps and gives end-user a more enterprise-like puppet test environment to start building their puppet modules.